### PR TITLE
Functional docker build action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,12 +21,12 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ghcr.io/placenl/placenl-bot:latest
+          tags: ghcr.io/placetud/placetud-soldat:latest
           platforms: linux/amd64,linux/arm64,linux/arm/v7


### PR DESCRIPTION
To simplify the process of running the latest bot on a server.

In order for the auth to ghcr.io to work the action access token needs permissions.
Can be done in the settings easily. See [Here](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-ghcrio)